### PR TITLE
NFRP update

### DIFF
--- a/dc/ws/NFRPCache.dn
+++ b/dc/ws/NFRPCache.dn
@@ -9,7 +9,6 @@ component provides ws.Web, Service requires io.Output out, ws.Web:nfrp web, inte
 		void Service:start() {
 			cache.clear()
 		}
-
 		void Service:stop() {
 			cache.clear()
 		}
@@ -38,8 +37,7 @@ component provides ws.Web, Service requires io.Output out, ws.Web:nfrp web, inte
 		}
 
 		bool Web:post(char path[], char contentType[], byte content[], DocStream stream, HashTable params) {
-			CachedData cD = cache.get(path)
-			if (cD != null) { cache.delete(path) }
+			cache.clear()
 			return web.post(path, contentType, content, stream, params)
 		}
 

--- a/dc/ws/NFRPCacheCompression.dn
+++ b/dc/ws/NFRPCacheCompression.dn
@@ -46,8 +46,7 @@ component provides ws.Web, Service requires io.Output out, ws.Web:nfrp web, inte
 		}
 
 		bool Web:post(char path[], char contentType[], byte content[], DocStream stream, HashTable params) {
-			CachedData cD = cache.get(path)
-			if (cD != null) { cache.delete(path) }
+			cache.clear()
 			return web.post(path, contentType, content, stream, params)
 		}
 


### PR DESCRIPTION
Whenever a post request is issued, in case of the composition has a NFRPCache or NFRPCacheCompression attached to its structure, the cache is completely cleaned out, invalidating all previously stored items.